### PR TITLE
Fixing Herika use moods, and GPT roles

### DIFF
--- a/addons/background/index.php
+++ b/addons/background/index.php
@@ -13,7 +13,7 @@ if ($_POST["doit"]) {
   
   $head[] = array('role' => 'system', 'content' => stripslashes($_POST["prompt"]));
   $prompt[] = array('role' => 'user', 'content' => "Generate a background story for $HERIKA_NAME, in first person, and how she ended in Whiterun, as she would write it into her diary");
-  $foot[] = array('role' => 'assistant', 'content' => '');
+  $foot[] = array('role' => 'user', 'content' => '');
 
   $parms=array_merge($head,$prompt,$foot);
   

--- a/chat/generic.php
+++ b/chat/generic.php
@@ -29,7 +29,7 @@ function requestGeneric($request, $preprompt = '', $queue = 'AASPGQuestDialogue2
     $foot = array();
 
     $head[] = array('role' => 'user', 'content' => '('.$PROMPT_HEAD.$GLOBALS["HERIKA_PERS"].$PROMPT_RULES);
-    $prompt[] = array('role' => 'assistant', 'content' => $request);
+    $prompt[] = array('role' => 'user', 'content' => $request);
     $foot[] = array('role' => 'user', 'content' => $GLOBALS["PLAYER_NAME"].':' . $preprompt);
 
 

--- a/lib/sql.class.php
+++ b/lib/sql.class.php
@@ -98,7 +98,13 @@ class sql
     while ($row = $results->fetchArray()) {
 
       if ($lastData!=md5($row["data"])) {
-        if ((strpos($row["data"],"{$GLOBALS["HERIKA_NAME"]}:")!==false)||((strpos($row["data"],"{$GLOBALS["PLAYER_NAME"]}:")!==false))) {
+        if ((strpos($row["data"],"{$GLOBALS["HERIKA_NAME"]}:")!==false)) {
+          $pattern = "/\([^)]*Context location[^)]*\)/";    // Remove (Context location.. from Herikas lines.
+          $replacement = "";
+          $row["data"] = preg_replace($pattern, $replacement, $row["data"]);
+          $lastDialogFull[] = array('role' => 'assistant', 'content' => $row["data"]);
+
+        } else if ((strpos($row["data"],"{$GLOBALS["PLAYER_NAME"]}:")!==false)) {
           $pattern = "/\([^)]*Context location[^)]*\)/";    // Remove (Context location.. from Herikas lines.
           $replacement = "";
           $row["data"] = preg_replace($pattern, $replacement, $row["data"]);

--- a/stream.php
+++ b/stream.php
@@ -192,7 +192,7 @@ $head = array();
 $foot = array();
 
 $head[] = array('role' => 'user', 'content' => '('.$PROMPT_HEAD.$GLOBALS["HERIKA_PERS"]);
-$prompt[] = array('role' => 'assistant', 'content' => $request);
+$prompt[] = array('role' => 'user', 'content' => $request);
 $foot[] = array('role' => 'user', 'content' => $GLOBALS["PLAYER_NAME"].':' . $preprompt);
 
 if (!$preprompt)

--- a/streamv2.php
+++ b/streamv2.php
@@ -514,10 +514,10 @@ if ($finalParsedData[0] == "funcret") {
 			$argName = "target";
 
 		}
-		$functionCalled[] = array('role' => 'user', 'content' => null, 'function_call' => array("name" => $returnFunction[1], "arguments" => "{\"$argName\":\"{$returnFunction[2]}\"}"));
+		$functionCalled[] = array('role' => 'assistant', 'content' => null, 'function_call' => array("name" => $returnFunction[1], "arguments" => "{\"$argName\":\"{$returnFunction[2]}\"}"));
 
 	} else
-		$functionCalled[] = array('role' => 'user', 'content' => null, 'function_call' => ["name" => $returnFunction[1], "arguments" => "\"{}\""]);
+		$functionCalled[] = array('role' => 'assistant', 'content' => null, 'function_call' => ["name" => $returnFunction[1], "arguments" => "\"{}\""]);
 
 	$returnFunctionArray[] = array('role' => 'function', 'name' => $returnFunction[1], 'content' => "{$returnFunction[3]}");
 

--- a/streamv2.php
+++ b/streamv2.php
@@ -437,7 +437,7 @@ $forceAttackingText = false;
 /**** CALL *******/
 
 if ($finalParsedData[0] == "funcret") {
-	$prompt[] = array('role' => 'assistant', 'content' => $request);
+	$prompt[] = array('role' => 'user', 'content' => $request);
 
 	$returnFunction = explode("@", $finalParsedData[3]); // Function returns here
 
@@ -514,17 +514,17 @@ if ($finalParsedData[0] == "funcret") {
 			$argName = "target";
 
 		}
-		$functionCalled[] = array('role' => 'assistant', 'content' => null, 'function_call' => array("name" => $returnFunction[1], "arguments" => "{\"$argName\":\"{$returnFunction[2]}\"}"));
+		$functionCalled[] = array('role' => 'user', 'content' => null, 'function_call' => array("name" => $returnFunction[1], "arguments" => "{\"$argName\":\"{$returnFunction[2]}\"}"));
 
 	} else
-		$functionCalled[] = array('role' => 'assistant', 'content' => null, 'function_call' => ["name" => $returnFunction[1], "arguments" => "\"{}\""]);
+		$functionCalled[] = array('role' => 'user', 'content' => null, 'function_call' => ["name" => $returnFunction[1], "arguments" => "\"{}\""]);
 
 	$returnFunctionArray[] = array('role' => 'function', 'name' => $returnFunction[1], 'content' => "{$returnFunction[3]}");
 
 	if ($forceAttackingText)
-		$returnFunctionArray[] = array('role' => 'assistant', 'content' => "{$PROMPTS["afterattack"][0]} {$GLOBALS["HERIKA_NAME"]}: ");
+		$returnFunctionArray[] = array('role' => 'user', 'content' => "{$PROMPTS["afterattack"][0]} {$GLOBALS["HERIKA_NAME"]}: ");
 	else
-		$returnFunctionArray[] = array('role' => 'assistant', 'content' => $request);
+		$returnFunctionArray[] = array('role' => 'user', 'content' => $request);
 
 
 	$parms = array_merge($head, ($contextDataFull), $functionCalled, $returnFunctionArray);
@@ -549,7 +549,7 @@ if ($finalParsedData[0] == "funcret") {
 } else if ( (strpos($finalParsedData[0],"chatnf")!==false)) {
 
 
-	$prompt[] = array('role' => 'assistant', 'content' => $request);
+	$prompt[] = array('role' => 'user', 'content' => $request);
 
 	$parms = array_merge($head, ($contextDataFull), $prompt);
 	$data = array(
@@ -566,7 +566,7 @@ if ($finalParsedData[0] == "funcret") {
 } else if ($finalParsedData[0] == "diary") {
 
 
-	$prompt[] = array('role' => 'assistant', 'content' => $request);
+	$prompt[] = array('role' => 'user', 'content' => $request);
 
 	$parms = array_merge($head, ($contextDataFull), $prompt);
 	$data = array(
@@ -584,7 +584,7 @@ if ($finalParsedData[0] == "funcret") {
 
 } else {
 
-	$prompt[] = array('role' => 'assistant', 'content' => $request);
+	$prompt[] = array('role' => 'user', 'content' => $request);
 	$parms = array_merge($head, ($contextDataFull), $prompt);
 	$data = array(
 		'model' => (isset($GLOBALS["GPTMODEL"]))?$GLOBALS["GPTMODEL"]:'gpt-3.5-turbo-0613',
@@ -772,8 +772,8 @@ if ($handle === false) {
 
 			$buffer = strtr($buffer, array("\"" => ""));
 
-			$pattern = "/\([^()]*\)/"; // Modified pattern to remove unmatched opening parentheses
-			$buffer = preg_replace($pattern, "", $buffer);
+			//$pattern = "/\([^()]*\)/"; // Modified pattern to remove unmatched opening parentheses
+			//$buffer = preg_replace($pattern, "", $buffer);
 
 			if (strlen($buffer) < MAXIMUM_SENTENCE_SIZE) // Avoid too short buffers
 				continue;


### PR DESCRIPTION
- Fixed Herika using GPT roles incorrectly, it will now use role user to prompt GPT instead of assistant. Assistant role is only for storing past GPT responses in memory/context. (this also makes her much more likely to use voice tones/moods)  
- Herika will now store her responses as Assistant role  
- Fixed TTS not using the voice tones/moods if they are mentioned in GPT response e.g. (sad). Commented out 2 lines inside processing streaming response which was removing the moods too early  
