### PR TITLE
Add OpenAI cost monitoring support

### DIFF
--- a/chat/generic.php
+++ b/chat/generic.php
@@ -52,17 +52,19 @@ function requestGeneric($request, $preprompt = '', $queue = 'AASPGQuestDialogue2
     $headers = array(
     'Content-Type: application/json',
     "Authorization: Bearer {$GLOBALS["OPENAI_API_KEY"]}"
-);
-
+	);
+	$jsonEncodedData = json_encode($data);
     $options = array(
         'http' => array(
             'method' => 'POST',
             'header' => implode("\r\n", $headers),
-            'content' => json_encode($data),
+            'content' => $jsonEncodedData,
             'timeout' => ($GLOBALS["HTTP_TIMEOUT"]) ?: 30
         )
     );
 
+    // call into tokenizer and tokenize request as part of OpenAI cost monitoring - save result in DB
+    tokenizePrompt($jsonEncodedData);
 
     $url = 'https://api.openai.com/v1/chat/completions';
 

--- a/cmd/install-db.php
+++ b/cmd/install-db.php
@@ -15,6 +15,18 @@ CREATE TABLE IF NOT EXISTS `eventlog` (
   `localts` bigint NOT NULL
 );");
 
+$db->exec("
+CREATE TABLE IF NOT EXISTS `openai_token_count` (
+  `input_tokens` bigint NOT NULL,
+  `output_tokens` bigint NOT NULL ,
+  `total_tokens_so_far` bigint NOT NULL ,
+  `cost_USD` float ,
+  `total_cost_so_far_USD` float,
+  `localts` bigint NOT NULL,
+  `datetime` text,
+  `model` text
+);");
+
 //$db->exec("DROP TABLE `responselog`;");
 
 $db->exec("

--- a/index.php
+++ b/index.php
@@ -186,6 +186,12 @@ include("tmpl/navbar.php");
         echo "<h3 class='my-2'>Book log</h3>";
         print_array_as_table($results);
     } 
+
+    if ($_GET["table"] == "openai_token_count") {
+        $results = $db->fetchAll("select  A.*,ROWID FROM openai_token_count A order by rowid desc");
+        echo "<h3 class='my-2'>OpenAI token pricing</h3>";
+        print_array_as_table($results);
+    }
         
     if ($_GET["notes"]) {
         echo file_get_contents(__DIR__."/notes.html");

--- a/lib/sql.class.php
+++ b/lib/sql.class.php
@@ -27,6 +27,30 @@ class sql
 
   }
 
+  // used for openai_token_count table
+  function insert_and_calc_totals($table, $data)
+  {
+      // Fetch the last row
+      $latestRowQuery = "SELECT * FROM $table ORDER BY ROWID DESC LIMIT 1";
+      $latestRowResult = self::fetchAll($latestRowQuery);
+
+      if (!empty($latestRowResult)) {
+          // If the table is not empty
+          $latestRow = $latestRowResult[0];
+
+          // Calculate totals
+          $data['total_tokens_so_far'] = $latestRow['total_tokens_so_far'] + $data['input_tokens'] + $data['output_tokens'];
+          $data['total_cost_so_far_USD'] = $latestRow['total_cost_so_far_USD'] + $data['cost_USD'];
+      } else {
+          // If the table is empty
+          $data['total_tokens_so_far'] = $data['input_tokens'] + $data['output_tokens'];
+          $data['total_cost_so_far_USD'] = $data['cost_USD'];
+      }
+
+      // Insert new row
+      self::$link->exec("INSERT INTO $table (" . implode(",", array_keys($data)) . ") VALUES ('" . implode("','", $data) . "')");
+  }
+
   function query($query)
   {
 

--- a/tmpl/navbar.php
+++ b/tmpl/navbar.php
@@ -15,6 +15,7 @@
                     <li><a class="dropdown-item" href="index.php?table=currentmission">Current mission</a></li>
                     <li><a class="dropdown-item" href="index.php?table=diarylog">Diary</a></li>
                     <li><a class="dropdown-item" href="index.php?table=books">Books</a></li>
+                    <li><a class="dropdown-item" href="index.php?table=openai_token_count">OpenAI Token Pricing</a></li>
                     <li><a class="dropdown-item" href="index.php?table=eventlog&autorefresh=true">Monitor events</a></li>
                 </ul>
             </li>

--- a/tokenizer_server.py
+++ b/tokenizer_server.py
@@ -1,0 +1,82 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs
+import cgi, json
+import tiktoken
+import time
+
+class RequestHandler(BaseHTTPRequestHandler):
+    def _send_response(self, message):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+        self.wfile.write(bytes(message, "utf8"))
+
+    def num_tokens_from_messages(self, messages, model="gpt-3.5-turbo-0613"):
+        """Return the number of tokens used by a list of messages."""
+        try:
+            encoding = tiktoken.encoding_for_model(model)
+        except KeyError:
+            print("Warning: model not found. Using gpt-3.5-turbo-0613 encoding.")
+            encoding = tiktoken.get_encoding("gpt-3.5-turbo-0613")
+        if model in {
+            "gpt-3.5-turbo-0613",
+            "gpt-3.5-turbo-16k-0613",
+            "gpt-4-0314",
+            "gpt-4-32k-0314",
+            "gpt-4-0613",
+            "gpt-4-32k-0613",
+            }:
+            tokens_per_message = 3
+            tokens_per_name = 1
+        elif model == "gpt-3.5-turbo-0301":
+            tokens_per_message = 4  # every message follows <|start|>{role/name}\n{content}<|end|>\n
+            tokens_per_name = -1  # if there's a name, the role is omitted
+        elif "gpt-3.5-turbo" in model:
+            return num_tokens_from_messages(messages, model="gpt-3.5-turbo-0613")
+        elif "gpt-4" in model:
+            return num_tokens_from_messages(messages, model="gpt-4-0613")
+        else:
+            #raise NotImplementedError(
+            #    f"""num_tokens_from_messages() is not implemented for model {model}. See https://github.com/openai/openai-python/blob/main/chatml.md for information on how messages are converted to tokens."""
+            #)
+            return 0 # return 0 on error condition, better then breaking the app
+        num_tokens = 0
+        for message in messages:
+            num_tokens += tokens_per_message
+            for key, value in message.items():
+                # ignore non-str values (like 'function_call' which has dict as value)
+                if not isinstance(value, str):
+                    continue
+                num_tokens += len(encoding.encode(value))
+                if key == "name":
+                    num_tokens += tokens_per_name
+        num_tokens += 3  # every reply is primed with <|start|>assistant<|message|>
+        return num_tokens
+
+    def do_POST(self):
+        start_time = time.perf_counter()
+        ctype, pdict = cgi.parse_header(self.headers.get('content-type'))
+        if ctype == 'application/json':
+            length = int(self.headers.get('content-length'))
+            postvars = json.loads(self.rfile.read(length))
+            #print(postvars)
+            #start_time = time.perf_counter()
+            tok_num = self.num_tokens_from_messages(postvars['messages'], postvars['model'])
+            self._send_response(str(tok_num))
+            end_time = time.perf_counter()
+            execution_time = (end_time - start_time) * 1000  # Convert to milliseconds
+            with open('tokenizer_log_file.txt', 'a') as file: # this will end up in /tmp
+                file.write(f"The code executed in {execution_time}ms\n")
+                file.write(json.dumps(postvars))
+                file.write('\n')
+                #print(f"The code executed in {execution_time}ms")
+
+        else:
+            self.send_response(415)
+            self.end_headers()
+            self.wfile.write(bytes('Unsupported Media Type', 'utf-8'))
+
+port = 8090
+httpd = HTTPServer(('localhost', port), RequestHandler)
+print(f"Starting server on port {port}...")
+httpd.serve_forever()


### PR DESCRIPTION
Adds a Python tokenizer server running in the background (port 8090) and calls into
the tokenizer for every prompt that is being sent to OpenAI.
Tokenizer then returns the number of tokens and DB is updated (new table)
with the cost of the API call in USD.

Should look like this on the webpage:

<img width="780" alt="Capture" src="https://github.com/abeiro/saig-gwserver/assets/141279586/630dfe3b-6818-4132-a3cc-2aaca908765f">


NOTE:

this requires the following change in /etc/start_env in DwemerDistro (can be put right after mimic3)

nohup python3 /var/www/html/saig-gwserver/tokenizer_server.py &>/dev/null&

and also the following new variable in conf.php:

$COST_MONITOR_ENABLED=true;

Runtime log data of tokenizer in:
/tmp/tokenizer_log_file.txt
it shows how many milliseconds it took to tokenize and the whole OpenAI prompt