### PR TITLE
Do not override context length configured in koboldcpp

### DIFF
--- a/chat/generic.php
+++ b/chat/generic.php
@@ -117,13 +117,13 @@ function requestGeneric($request, $preprompt = '', $queue = 'AASPGQuestDialogue2
         }
         $context .= "\n{$GLOBALS["HERIKA_NAME"]}:";
         //$GLOBALS["DEBUG_DATA"]=explode("\n",$context);
+        $MAX_TOKENS=((isset($GLOBALS["KOBOLDCPP_MAX_TOKENS"])?$GLOBALS["KOBOLDCPP_MAX_TOKENS"]:80)+0);
         $postData = array(
 
             "prompt" => $context,
             "temperature" => 0.9,
             "top_p" => 0.9,
-            "max_context_length" => 1024,
-            "max_length" => 80,
+            "max_length" => $MAX_TOKENS,
             "rep_pen" => 1.1,
             "stop_sequence" => ["{$GLOBALS["PLAYER_NAME"]}:", "\\n{$GLOBALS["PLAYER_NAME"]} ", "The Narrator", "\n"]
         );

--- a/stream.php
+++ b/stream.php
@@ -431,7 +431,6 @@ if ( (!isset($GLOBALS["MODEL"]) || ($GLOBALS["MODEL"]=="openai"))) {
 			"prompt"=>$context,
 			"temperature"=> 0.7,
 			"top_p"=> 0.9,
-			"max_context_length"=>1024,
 			"max_length"=>$MAX_TOKENS,
 			"rep_pen"=>1.1,
 			"stop_sequence"=>$stop_sequence
@@ -446,7 +445,6 @@ if ( (!isset($GLOBALS["MODEL"]) || ($GLOBALS["MODEL"]=="openai"))) {
 			"prompt"=>$context,
 			"temperature"=> 0.9,
 			"top_p"=> 0.9,
-			"max_context_length"=>1024,
 			"max_length"=>$MAX_TOKENS,
 			"rep_pen"=>1.1,
 			"stop_sequence"=>$stop_sequence


### PR DESCRIPTION
Looks like max_context_length sent in API request overrides the context length setting in koboldcpp GUI or command line configuration. I think we don't want this, so I removed it.
Also made sure max_length (response length) depends on the conf var if it is set