### PR TITLE
feat: OpenAI and Openrouter compliant requests

### DIFF
--- a/stream.php
+++ b/stream.php
@@ -384,7 +384,9 @@ if ( (!isset($GLOBALS["MODEL"]) || ($GLOBALS["MODEL"]=="openai"))) {
  
 	$headers = array(
 		'Content-Type: application/json',
-		"Authorization: Bearer {$GLOBALS["OPENAI_API_KEY"]}"
+		"Authorization: Bearer {$GLOBALS["OPENAI_API_KEY"]}",
+		'HTTP-Referer: http://localhost:8081/saig-gwserver/',	// value doesn't matter, mandatory for Openrouter
+		'X-Title: Herika'										// Billing Identifier, mandatory for Openrouter
 	);
 
 	$options = array(


### PR DESCRIPTION
Extended the HTTP Headers to be compliant with OpenAI API and Openrouter API.

This way you *could* connect openrouter by overwriting `$OPENAI_URL`, `$GPTMODEL` and `$OPENAI_API_KEY` in conf.php.
Obviously, overwriting `$OPENAI_API_KEY` in your conf.php will effectively kill authentication for OpenAI Whisper and OpenAI text-embedding. So this isn't a feature for enabling Openrouter usage, but just to have the generated request compliant with BOTH service providers.