### PR TITLE
fix: unnecessary isset

### DIFF
--- a/chat/generic.php
+++ b/chat/generic.php
@@ -90,7 +90,7 @@ function requestGeneric($request, $preprompt = '', $queue = 'AASPGQuestDialogue2
         $sentence = cleanReponse($rawResponse);
 
 
-    } else if ((isset($GLOBALS["MODEL"]) || ($GLOBALS["MODEL"] == "koboldcpp"))) {
+    } else if ($GLOBALS["MODEL"] == "koboldcpp") {
         $GLOBALS["DEBUG_DATA"] = []; //reset
 
         $context = "";

--- a/stream.php
+++ b/stream.php
@@ -401,7 +401,7 @@ if ( (!isset($GLOBALS["MODEL"]) || ($GLOBALS["MODEL"]=="openai"))) {
 	$GLOBALS["DEBUG_DATA"][]=$parms;
 
 
-} else if ( (isset($GLOBALS["MODEL"]) || ($GLOBALS["MODEL"]=="koboldcpp")))  {
+} else if ($GLOBALS["MODEL"]=="koboldcpp")  {
 	$GLOBALS["DEBUG_DATA"]=[];//reset
 	consoleLog("koboldcpp type call");
 
@@ -567,7 +567,7 @@ if ($handle === false) {
 			$totalBuffer.=$data["choices"][0]["delta"]["content"];
 			}
 
-		} else if ( (isset($GLOBALS["MODEL"]) || ($GLOBALS["MODEL"]=="koboldcpp")))  {
+		} else if ($GLOBALS["MODEL"]=="koboldcpp")  {
 			error_reporting(E_ERROR);
 			if (feof($handle)) {
 				$breakFlag=true;

--- a/stream.php
+++ b/stream.php
@@ -595,7 +595,7 @@ if ($handle === false) {
 		if ( (!isset($GLOBALS["MODEL"]) || ($GLOBALS["MODEL"]=="openai"))) {
 			if (feof($handle))
 				$breakFlag=true;
-		} else if ( (isset($GLOBALS["MODEL"]) || ($GLOBALS["MODEL"]=="koboldcpp")))  {
+		} else if ($GLOBALS["MODEL"]=="koboldcpp")  {
 			if (feof($handle))
 				$breakFlag=true;
 				


### PR DESCRIPTION
`(isset($GLOBALS["MODEL"]) ||` is unnecessary.
Condition is always 'true' because '(!isset($GLOBALS["MODEL"]) || ($GLOBALS["MODEL"] == "openai"))' is already 'false' at this point. Like, if we enter the else-if at that both none of both options was true, therefore $GLOBALS["MODEL"] has to be set..